### PR TITLE
ci(release): Publish signed FOSS APKs

### DIFF
--- a/.github/workflows/publish-fdroid-reference.yml
+++ b/.github/workflows/publish-fdroid-reference.yml
@@ -1,0 +1,282 @@
+name: Publish F-Droid reference APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag, for example v0.32
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fdroid-reference-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build FOSS APK for ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+
+    steps:
+      - name: Validate tag input
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "$RELEASE_TAG" in
+            v0.31)
+              expected_commit="724187d01e7472fa9e7151ebe825fdd18acb199d"
+              ;;
+            v0.32)
+              expected_commit="65a93dc6b962cbae492226ac896dac60026939ef"
+              ;;
+            *)
+              echo "Only the v0.31 and v0.32 backfills are allowed." >&2
+              exit 1
+              ;;
+          esac
+
+          echo "EXPECTED_COMMIT=${expected_commit}" >> "$GITHUB_ENV"
+
+      - name: Check out release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Validate release metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_TAG#v}"
+          project_version="$(sed -n 's/^candy\.versionName=//p' gradle.properties)"
+          version_code="$(sed -n 's/^candy\.versionCode=//p' gradle.properties)"
+
+          if [[ "$(git rev-parse HEAD)" != "$EXPECTED_COMMIT" ]]; then
+            echo "Tag ${RELEASE_TAG} does not resolve to the pinned release commit." >&2
+            exit 1
+          fi
+
+          if [[ "$version" != "$project_version" ]]; then
+            echo "Tag ${RELEASE_TAG} does not match gradle.properties ${project_version}." >&2
+            exit 1
+          fi
+
+          if [[ ! "$version_code" =~ ^[1-9][0-9]*$ ]] || (( version_code > 2100000000 )); then
+            echo "Version code must be between 1 and 2100000000." >&2
+            exit 1
+          fi
+
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Test and build unsigned FOSS APK
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ./gradlew --no-daemon \
+            testFossReleaseUnitTest \
+            assembleFossRelease
+
+      - name: Store unsigned FOSS APK
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fdroid-reference-${{ inputs.tag }}
+          path: app/build/outputs/apk/foss/release/app-foss-release-unsigned.apk
+          if-no-files-found: error
+          retention-days: 1
+
+  sign-and-publish:
+    name: Sign and publish FOSS APK for ${{ inputs.tag }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+
+    steps:
+      - name: Download unsigned FOSS APK
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: fdroid-reference-${{ inputs.tag }}
+          path: input
+
+      - name: Validate immutable release tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          case "$RELEASE_TAG" in
+            v0.31)
+              expected_commit="724187d01e7472fa9e7151ebe825fdd18acb199d"
+              ;;
+            v0.32)
+              expected_commit="65a93dc6b962cbae492226ac896dac60026939ef"
+              ;;
+            *)
+              echo "Only the v0.31 and v0.32 backfills are allowed." >&2
+              exit 1
+              ;;
+          esac
+
+          tag_object="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" \
+              --jq '.object.type + " " + .object.sha'
+          )"
+          if [[ "$tag_object" != "commit ${expected_commit}" ]]; then
+            echo "Tag ${RELEASE_TAG} does not resolve to the pinned release commit." >&2
+            exit 1
+          fi
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+
+      - name: Restore release keystore
+        shell: bash
+        env:
+          CANDY_RELEASE_KEYSTORE_BASE64: ${{ secrets.CANDY_RELEASE_KEYSTORE_BASE64 }}
+          CANDY_RELEASE_STORE_PASSWORD: ${{ secrets.CANDY_RELEASE_STORE_PASSWORD }}
+          CANDY_RELEASE_KEY_ALIAS: ${{ secrets.CANDY_RELEASE_KEY_ALIAS }}
+          CANDY_RELEASE_KEY_PASSWORD: ${{ secrets.CANDY_RELEASE_KEY_PASSWORD }}
+          CANDY_RELEASE_CERTIFICATE_SHA256: ${{ vars.CANDY_RELEASE_CERTIFICATE_SHA256 }}
+        run: |
+          set -euo pipefail
+
+          required_variables=(
+            CANDY_RELEASE_KEYSTORE_BASE64
+            CANDY_RELEASE_STORE_PASSWORD
+            CANDY_RELEASE_KEY_ALIAS
+            CANDY_RELEASE_KEY_PASSWORD
+            CANDY_RELEASE_CERTIFICATE_SHA256
+          )
+          for variable in "${required_variables[@]}"; do
+            if [[ -z "${!variable:-}" ]]; then
+              echo "Missing release configuration: ${variable}" >&2
+              exit 1
+            fi
+          done
+
+          keystore_path="$RUNNER_TEMP/candy-release.jks"
+          printf '%s' "$CANDY_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
+          chmod 600 "$keystore_path"
+          keytool -list \
+            -keystore "$keystore_path" \
+            -storepass:env CANDY_RELEASE_STORE_PASSWORD \
+            -alias "$CANDY_RELEASE_KEY_ALIAS" \
+            >/dev/null
+
+          expected_certificate="${CANDY_RELEASE_CERTIFICATE_SHA256//:/}"
+          expected_certificate="${expected_certificate,,}"
+          if [[ ! "$expected_certificate" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "CANDY_RELEASE_CERTIFICATE_SHA256 must contain a SHA-256 certificate digest." >&2
+            exit 1
+          fi
+
+          actual_certificate="$(
+            keytool -exportcert \
+              -keystore "$keystore_path" \
+              -storepass:env CANDY_RELEASE_STORE_PASSWORD \
+              -alias "$CANDY_RELEASE_KEY_ALIAS" \
+              | sha256sum \
+              | cut -d ' ' -f 1
+          )"
+          if [[ "$actual_certificate" != "$expected_certificate" ]]; then
+            echo "Release keystore certificate does not match pinned repository fingerprint." >&2
+            exit 1
+          fi
+
+          echo "CANDY_RELEASE_KEYSTORE_PATH=${keystore_path}" >> "$GITHUB_ENV"
+
+      - name: Validate, sign, and publish F-Droid reference APK
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDY_RELEASE_STORE_PASSWORD: ${{ secrets.CANDY_RELEASE_STORE_PASSWORD }}
+          CANDY_RELEASE_KEY_ALIAS: ${{ secrets.CANDY_RELEASE_KEY_ALIAS }}
+          CANDY_RELEASE_KEY_PASSWORD: ${{ secrets.CANDY_RELEASE_KEY_PASSWORD }}
+          CANDY_RELEASE_CERTIFICATE_SHA256: ${{ vars.CANDY_RELEASE_CERTIFICATE_SHA256 }}
+        run: |
+          set -euo pipefail
+
+          unsigned_apk="input/app-foss-release-unsigned.apk"
+          foss_release_apk="CandyBrowser-${RELEASE_TAG}-foss-release.apk"
+          apksigner="$ANDROID_HOME/build-tools/34.0.0/apksigner"
+          aapt="$ANDROID_HOME/build-tools/34.0.0/aapt"
+          if [[ ! -x "$apksigner" || ! -x "$aapt" ]]; then
+            echo "Android Build Tools 34.0.0 are required for F-Droid-compatible signing." >&2
+            exit 1
+          fi
+
+          badging="$("$aapt" dump badging "$unsigned_apk")"
+          package_name="$(printf '%s\n' "$badging" | sed -nE "s/^package: name='([^']+)'.*$/\1/p")"
+          version_name="$(printf '%s\n' "$badging" | sed -nE "s/^package: .*versionName='([^']+)'.*$/\1/p")"
+          if [[ "$package_name" != "dev.sk2andy.materialbrowser" ]]; then
+            echo "Unexpected application ID: ${package_name}" >&2
+            exit 1
+          fi
+          if [[ "v${version_name}" != "$RELEASE_TAG" ]]; then
+            echo "APK version ${version_name} does not match ${RELEASE_TAG}." >&2
+            exit 1
+          fi
+          if "$apksigner" verify "$unsigned_apk" >/dev/null 2>&1; then
+            echo "Build artifact is unexpectedly signed." >&2
+            exit 1
+          fi
+
+          "$apksigner" sign \
+            --ks "$CANDY_RELEASE_KEYSTORE_PATH" \
+            --ks-key-alias "$CANDY_RELEASE_KEY_ALIAS" \
+            --ks-pass env:CANDY_RELEASE_STORE_PASSWORD \
+            --key-pass env:CANDY_RELEASE_KEY_PASSWORD \
+            --out "$foss_release_apk" \
+            "$unsigned_apk"
+
+          expected_certificate="${CANDY_RELEASE_CERTIFICATE_SHA256//:/}"
+          expected_certificate="${expected_certificate,,}"
+          verification="$("$apksigner" verify --verbose --print-certs "$foss_release_apk")"
+          printf '%s\n' "$verification"
+          actual_certificate="$(
+            printf '%s\n' "$verification" \
+              | sed -nE 's/^.*certificate SHA-256 digest: ([[:xdigit:]:]+)$/\1/p' \
+              | tr '[:upper:]' '[:lower:]' \
+              | tr -d ':' \
+              | sort -u
+          )"
+          if [[ "$actual_certificate" != "$expected_certificate" ]]; then
+            echo "${foss_release_apk} certificate does not match pinned repository fingerprint." >&2
+            exit 1
+          fi
+
+          sha256sum "$foss_release_apk" > "${foss_release_apk}.sha256"
+          gh release upload \
+            "$RELEASE_TAG" \
+            "$foss_release_apk" \
+            "${foss_release_apk}.sha256" \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Remove release keystore
+        if: always()
+        shell: bash
+        run: rm -f -- "$RUNNER_TEMP/candy-release.jks"

--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ Candy Browser requires Android 13 (API 33) or newer.
 
 [Download Candy Browser](https://github.com/sk2andy/candy-browser/releases)
 
-Production builds check GitHub for updates at startup and offer the signed APK for download. Android
-still requires you to open the downloaded file and approve installation.
+Standard and User CA production builds check GitHub for updates at startup and offer the signed APK
+for download. The FOSS build disables this updater. Android still requires you to open a downloaded
+file and approve installation.
 
 ### Obtainium
 
@@ -176,30 +177,33 @@ Use the filtered setup link so Obtainium always selects the standard certificate
 
 [![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png)](https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fapp%2F%7B%22id%22%3A%22dev.sk2andy.materialbrowser%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fsk2andy%2Fcandy-browser%22%2C%22author%22%3A%22sk2andy%22%2C%22name%22%3A%22Candy%20Browser%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22apkFilterRegEx%5C%22%3A%5C%22%5ECandyBrowser-v%5B0-9%5D%2B(%3F%3A%5C%5C%5C%5C.%5B0-9%5D%2B)%7B1%2C2%7D-release%5C%5C%5C%5C.apk%24%5C%22%7D%22%7D)
 
-Both GitHub APK channels use the same application ID and signing key. Obtainium can track only one
-of them at a time. Do not add the unfiltered repository URL: the release contains two installable
-APKs and choosing the wrong asset can silently switch the installed certificate-trust policy.
+All GitHub APK channels use the same application ID and signing key. Obtainium can track only one
+of them at a time. Do not add the unfiltered repository URL: the release contains three installable
+APKs, and choosing the wrong asset can silently switch the installed feature set or certificate-trust
+policy.
 
 ### F-Droid
 
 Candy includes a `foss` distribution flavor for the official F-Droid repository. It removes Google
 Play services, Google Cast, Google Code Scanner, and Candy's GitHub update checker. Remote search
-suggestions default to off. F-Droid builds and signs this variant from the tagged public source.
+suggestions default to off. F-Droid builds this variant from tagged public source and verifies it
+against Candy's upstream-signed FOSS APK.
 
 The first prepared F-Droid release is `0.31`. Submission files and the remaining maintainer steps
-live in [`distribution/fdroid`](distribution/fdroid/README.md). Because F-Droid normally signs with
-its own key, switching between a GitHub/Obtainium installation and F-Droid requires uninstalling the
-existing app first.
+live in [`distribution/fdroid`](distribution/fdroid/README.md). Candy publishes a signed FOSS
+reference APK so F-Droid can verify its source build and preserve update compatibility with the
+upstream signing key.
 
-Releases contain two APK channels:
+Releases contain three APK channels:
 
 | APK suffix | Certificate trust | Intended use |
 | --- | --- | --- |
 | `-release.apk` | Android system CAs only | Recommended default |
+| `-foss-release.apk` | Android system CAs only | F-Droid reproducible-build reference without proprietary Google integrations |
 | `-user-ca-release.apk` | System CAs plus every CA in Android's user store | Explicit opt-in for HTTPS filtering/proxy tools such as AdGuard |
 
-The User CA build has the same application ID and signing key as the standard build, so installing it
-replaces the other channel without clearing Candy's data. Its launcher label and the warning under
+The User CA build has the same application ID and signing key as the other builds, so installing it
+replaces another channel without clearing Candy's data. Its launcher label and the warning under
 **Settings → Protection & data** identify the broader trust policy. Updates stay on the installed
 channel.
 
@@ -277,15 +281,16 @@ Signed local APK: `app/build/outputs/apk/full/localRelease/app-full-localRelease
 
 `localRelease` installs beside the GitHub build as `dev.sk2andy.materialbrowser.local` and uses a
 separate launcher icon and the label `Candy Browser Local`. GitHub update prompts are disabled for
-this side-by-side build because production APKs cannot update its package. The GitHub workflow uses
-`assembleFullRelease` and `assembleFullUserCaRelease`; both preserve the production application ID
-and icon. It also builds `assembleFossRelease` as source-build verification but does not publish it.
+this side-by-side build because production APKs cannot update its package. The GitHub release
+workflow uses `assembleFullRelease`, `assembleFossRelease`, and `assembleFullUserCaRelease`; all
+preserve the production application ID and icon. A separate workflow signs and publishes the FOSS
+output from explicitly allowlisted release tags.
 
 ### GitHub releases
 
-The manual `Release Android APK` workflow tests the selected source revision, builds and verifies the
-signed standard and User CA APKs, creates a `v<version>` source tag, and publishes both APKs plus
-their SHA-256 checksums. Add four repository secrets once:
+The manual `Release Android APK` workflow tests the selected source revision, builds the FOSS flavor,
+builds and verifies the signed standard and User CA APKs, creates a `v<version>` source tag, and
+publishes the two signed APKs plus their SHA-256 checksums. Add four repository secrets once:
 
 ```bash
 base64 < "$CANDY_RELEASE_KEYSTORE_PATH" | gh secret set CANDY_RELEASE_KEYSTORE_BASE64
@@ -307,6 +312,12 @@ keytool -exportcert \
   | gh variable set CANDY_RELEASE_CERTIFICATE_SHA256
 ```
 
+The separate `Publish F-Droid reference APK` workflow builds without access to signing secrets, then
+passes the unsigned APK to an isolated signing job that executes no repository code. It accepts only
+explicitly allowlisted release tags and commits and uses Android Build Tools 34 for compatibility
+with F-Droid's signature-copying process. F-Droid accepts the resulting signed APK only when its
+independent build matches byte for byte apart from signing.
+
 The workflow uses the `release` GitHub environment. Configure required reviewers for that environment
 if releases should require a manual approval after dispatch.
 
@@ -319,6 +330,15 @@ gh workflow run release.yml \
   -f version=0.32 \
   -f prerelease=false
 ```
+
+Publish a FOSS reference APK from an allowlisted release tag with:
+
+```bash
+gh workflow run publish-fdroid-reference.yml -f tag=v0.31
+```
+
+Before each later F-Droid release, add its exact tag and immutable commit to the workflow allowlist
+through normal code review, then dispatch the workflow.
 
 Android `versionCode` is stored in source so GitHub and F-Droid can build identical version
 metadata from a tag. Tags and releases are created only after full and FOSS tests, release build

--- a/distribution/fdroid/README.md
+++ b/distribution/fdroid/README.md
@@ -5,21 +5,23 @@ same application ID as the GitHub build but excludes Google Play services, Googl
 Scanner, and the GitHub self-updater. New FOSS installs keep remote search suggestions disabled
 until the user explicitly chooses a provider.
 
-## First submission
+## Submission
 
-1. Merge these changes and run the `Release Android APK` workflow for `0.31`. The workflow must
-   create tag `v0.31` from the exact commit that contains `candy.versionName=0.31` and
-   `candy.versionCode=31000`.
-2. Resolve the tag to its immutable commit:
+1. Run the `Release Android APK` workflow. It must create the version tag from the exact commit that
+   contains the matching `candy.versionName` and `candy.versionCode` values.
+2. For releases created before signed FOSS assets were enabled, run the backfill workflow from the
+   default branch:
 
    ```bash
-   git rev-list -n 1 v0.31
+   gh workflow run publish-fdroid-reference.yml -f tag=v0.31
+   gh workflow run publish-fdroid-reference.yml -f tag=v0.32
    ```
 
-3. Copy `dev.sk2andy.materialbrowser.yml` into a fork of `fdroid/fdroiddata` as
-   `metadata/dev.sk2andy.materialbrowser.yml`. Replace `REPLACE_WITH_V0.31_COMMIT_SHA` with the
-   40-character result from step 2.
-4. Validate from the fdroiddata checkout:
+3. Verify that each signed FOSS asset uses the pinned certificate fingerprint and matches the
+   independently built F-Droid APK byte for byte apart from signing.
+4. Copy `dev.sk2andy.materialbrowser.yml` into a fork of `fdroid/fdroiddata` as
+   `metadata/dev.sk2andy.materialbrowser.yml`.
+5. Validate from the fdroiddata checkout:
 
    ```bash
    fdroid readmeta
@@ -29,7 +31,7 @@ until the user explicitly chooses a provider.
    fdroid build -v -l dev.sk2andy.materialbrowser
    ```
 
-5. Open a merge request against `fdroid/fdroiddata`. Include the successful local-build log and
+6. Open a merge request against `fdroid/fdroiddata`. Include the successful local-build log and
    explain that the `full` flavor contains optional Google integrations while `foss` resolves no
    Google/Firebase/ML Kit runtime dependencies.
 
@@ -39,10 +41,10 @@ or search-suggestion request on a new install. If that default changes, reassess
 
 ## Signing boundary
 
-The first submission uses normal F-Droid signing. Users cannot update directly between an
-F-Droid-signed installation and the upstream GitHub/Obtainium installation. Reproducible builds
-with upstream signature verification can be evaluated later; do not add `Binaries` or
-`AllowedAPKSigningKeys` until byte-for-byte reproduction has been proven independently.
+`Binaries` and `AllowedAPKSigningKeys` make F-Droid compare its source build with Candy's signed FOSS
+APK. Keep those fields only while every referenced version passes that comparison. This lets F-Droid
+publish the upstream-signed APK and avoids a signing-key boundary between F-Droid, GitHub, and
+Obtainium installations.
 
 ## Release maintenance
 

--- a/distribution/fdroid/dev.sk2andy.materialbrowser.yml
+++ b/distribution/fdroid/dev.sk2andy.materialbrowser.yml
@@ -11,20 +11,23 @@ Donate: https://buymeacoffee.com/sk2andy
 
 RepoType: git
 Repo: https://github.com/sk2andy/candy-browser.git
+Binaries: https://github.com/sk2andy/candy-browser/releases/download/v%v/CandyBrowser-v%v-foss-release.apk
 
 Builds:
   - versionName: '0.31'
     versionCode: 31000
-    commit: REPLACE_WITH_V0.31_COMMIT_SHA
+    commit: 724187d01e7472fa9e7151ebe825fdd18acb199d
     subdir: app
     gradle:
       - foss
   - versionName: '0.32'
     versionCode: 32000
-    commit: REPLACE_WITH_V0.32_COMMIT_SHA
+    commit: 65a93dc6b962cbae492226ac896dac60026939ef
     subdir: app
     gradle:
       - foss
+
+AllowedAPKSigningKeys: e65082d293039290b24b6ef689996cf42f8e8b61966a2ebe4f49d9f8e486b7d3
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^v[0-9]+(\.[0-9]+){1,2}$


### PR DESCRIPTION
Add a guarded workflow that publishes signed FOSS reference APKs for the exact v0.31 and v0.32 release commits. This lets the open F-Droid submission compare its independent source builds with upstream-signed APKs while leaving the existing standard/User CA release workflow unchanged.

The build job has read-only permissions, retains no checkout credentials, and receives no signing secrets. A separate signing job executes no checked-out repository code, revalidates the immutable tag target, checks the application ID, version, and unsigned state, pins Android Build Tools 34 for F-Droid compatibility, verifies the certificate fingerprint, and uploads without overwriting existing assets.

Update release documentation and the source-owned F-Droid metadata template for the three APK channels and reproducible-build signing path. Future F-Droid release tags must be added to the exact tag/commit allowlist through normal code review before dispatch.

Validated with actionlint, YAML parsing, diff checks, and `./gradlew --no-daemon testFossReleaseUnitTest assembleFossRelease`.

Context: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/47593