### PR TITLE
fix(release): Make F-Droid signatures reproducible

### DIFF
--- a/.github/workflows/publish-fdroid-reference.yml
+++ b/.github/workflows/publish-fdroid-reference.yml
@@ -250,6 +250,10 @@ jobs:
             --ks-key-alias "$CANDY_RELEASE_KEY_ALIAS" \
             --ks-pass env:CANDY_RELEASE_STORE_PASSWORD \
             --key-pass env:CANDY_RELEASE_KEY_PASSWORD \
+            --v1-signing-enabled false \
+            --v2-signing-enabled true \
+            --v3-signing-enabled true \
+            --v4-signing-enabled false \
             --out "$foss_release_apk" \
             "$unsigned_apk"
 

--- a/README.md
+++ b/README.md
@@ -315,8 +315,10 @@ keytool -exportcert \
 The separate `Publish F-Droid reference APK` workflow builds without access to signing secrets, then
 passes the unsigned APK to an isolated signing job that executes no repository code. It accepts only
 explicitly allowlisted release tags and commits and uses Android Build Tools 34 for compatibility
-with F-Droid's signature-copying process. F-Droid accepts the resulting signed APK only when its
-independent build matches byte for byte apart from signing.
+with F-Droid's signature-copying process. Reference APKs disable the legacy v1/JAR signature and
+enable modern APK signature schemes so F-Droid can copy the signature onto its independent build.
+F-Droid accepts the resulting signed APK only when that build matches byte for byte apart from
+signing.
 
 The workflow uses the `release` GitHub environment. Configure required reviewers for that environment
 if releases should require a manual approval after dispatch.


### PR DESCRIPTION
## Context

F-Droid builds the FOSS flavor independently and uses `apksigcopier` to transfer the upstream signature. The reference APKs published by PR #34 contained a legacy v1/JAR signature; copying that signature produced an APK Signature Scheme v3 digest mismatch even though the unsigned APK payload was byte-identical.

## Change

Disable v1/JAR signing explicitly and enable the modern APK signature schemes in the isolated reference-signing job. Document the compatibility requirement for future releases.

## Evidence

The same F-Droid-built v0.31 unsigned APK fails `apksigcopier compare` when signed with v1 enabled and passes when signed with these flags. Workflow YAML parsing and actionlint also pass.

Refs #34