### PR TITLE
ci(release): Allow F-Droid v0.33 reference

### DIFF
--- a/.github/workflows/publish-fdroid-reference.yml
+++ b/.github/workflows/publish-fdroid-reference.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag, for example v0.32
+        description: Existing release tag, for example v0.33
         required: true
         type: string
 
@@ -36,8 +36,11 @@ jobs:
             v0.32)
               expected_commit="65a93dc6b962cbae492226ac896dac60026939ef"
               ;;
+            v0.33)
+              expected_commit="4d7400de2ee3316743e69fefe396fe5807ad0b9d"
+              ;;
             *)
-              echo "Only the v0.31 and v0.32 backfills are allowed." >&2
+              echo "Release tag is not explicitly allowlisted." >&2
               exit 1
               ;;
           esac
@@ -136,8 +139,11 @@ jobs:
             v0.32)
               expected_commit="65a93dc6b962cbae492226ac896dac60026939ef"
               ;;
+            v0.33)
+              expected_commit="4d7400de2ee3316743e69fefe396fe5807ad0b9d"
+              ;;
             *)
-              echo "Only the v0.31 and v0.32 backfills are allowed." >&2
+              echo "Release tag is not explicitly allowlisted." >&2
               exit 1
               ;;
           esac

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ gh workflow run release.yml \
 Publish a FOSS reference APK from an allowlisted release tag with:
 
 ```bash
-gh workflow run publish-fdroid-reference.yml -f tag=v0.31
+gh workflow run publish-fdroid-reference.yml -f tag=v0.33
 ```
 
 Before each later F-Droid release, add its exact tag and immutable commit to the workflow allowlist

--- a/distribution/fdroid/dev.sk2andy.materialbrowser.yml
+++ b/distribution/fdroid/dev.sk2andy.materialbrowser.yml
@@ -28,7 +28,7 @@ Builds:
       - foss
   - versionName: '0.33'
     versionCode: 33000
-    commit: REPLACE_WITH_V0.33_COMMIT_SHA
+    commit: 4d7400de2ee3316743e69fefe396fe5807ad0b9d
     subdir: app
     gradle:
       - foss


### PR DESCRIPTION
Allow the isolated F-Droid reference publisher to build and attach the v0.33 FOSS APK.\n\nThe v0.33 tag now exists and resolves to immutable commit 4d7400de2ee3316743e69fefe396fe5807ad0b9d. This replaces the pre-release placeholder in fdroiddata metadata and pins that same commit in both workflow trust boundaries before any repository code is built or a signed asset is published.\n\nThe README publisher example now points at v0.33. The tag mapping was checked against GitHub and the patch passes whitespace validation.