### PR TITLE
feat(distribution): Isolate Android build channels

### DIFF
--- a/.github/workflows/publish-fdroid-reference.yml
+++ b/.github/workflows/publish-fdroid-reference.yml
@@ -32,15 +32,19 @@ jobs:
           case "$RELEASE_TAG" in
             v0.31)
               expected_commit="724187d01e7472fa9e7151ebe825fdd18acb199d"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             v0.32)
               expected_commit="65a93dc6b962cbae492226ac896dac60026939ef"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             v0.33)
               expected_commit="4d7400de2ee3316743e69fefe396fe5807ad0b9d"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             v0.36)
               expected_commit="3721a82f351dacea522be36773df45c36cede965"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             *)
               echo "Release tag is not explicitly allowlisted." >&2
@@ -49,6 +53,7 @@ jobs:
           esac
 
           echo "EXPECTED_COMMIT=${expected_commit}" >> "$GITHUB_ENV"
+          echo "EXPECTED_APPLICATION_ID=${expected_application_id}" >> "$GITHUB_ENV"
 
       - name: Check out release tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -138,15 +143,19 @@ jobs:
           case "$RELEASE_TAG" in
             v0.31)
               expected_commit="724187d01e7472fa9e7151ebe825fdd18acb199d"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             v0.32)
               expected_commit="65a93dc6b962cbae492226ac896dac60026939ef"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             v0.33)
               expected_commit="4d7400de2ee3316743e69fefe396fe5807ad0b9d"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             v0.36)
               expected_commit="3721a82f351dacea522be36773df45c36cede965"
+              expected_application_id="dev.sk2andy.materialbrowser"
               ;;
             *)
               echo "Release tag is not explicitly allowlisted." >&2
@@ -163,6 +172,7 @@ jobs:
             echo "Tag ${RELEASE_TAG} does not resolve to the pinned release commit." >&2
             exit 1
           fi
+          echo "EXPECTED_APPLICATION_ID=${expected_application_id}" >> "$GITHUB_ENV"
           gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
 
       - name: Restore release keystore
@@ -244,7 +254,7 @@ jobs:
           badging="$("$aapt" dump badging "$unsigned_apk")"
           package_name="$(printf '%s\n' "$badging" | sed -nE "s/^package: name='([^']+)'.*$/\1/p")"
           version_name="$(printf '%s\n' "$badging" | sed -nE "s/^package: .*versionName='([^']+)'.*$/\1/p")"
-          if [[ "$package_name" != "dev.sk2andy.materialbrowser" ]]; then
+          if [[ "$package_name" != "$EXPECTED_APPLICATION_ID" ]]; then
             echo "Unexpected application ID: ${package_name}" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,20 @@ jobs:
             assembleFossRelease \
             assembleFullUserCaRelease
           CANDY_STANDARD_APK="app/build/outputs/apk/full/release/app-full-release.apk" \
+            CANDY_FOSS_APK="app/build/outputs/apk/foss/release/app-foss-release.apk" \
             CANDY_USER_CA_APK="app/build/outputs/apk/full/userCaRelease/app-full-userCaRelease.apk" \
+            CANDY_STANDARD_APPLICATION_ID="dev.sk2andy.materialbrowser" \
+            CANDY_FOSS_APPLICATION_ID="dev.sk2andy.materialbrowser.foss" \
+            CANDY_USER_CA_APPLICATION_ID="dev.sk2andy.materialbrowser.ca" \
+            CANDY_STANDARD_APP_LABEL="Candy Browser" \
+            CANDY_FOSS_APP_LABEL="Candy FOSS" \
+            CANDY_USER_CA_APP_LABEL="Candy CA" \
+            CANDY_STANDARD_LAUNCHER_FOREGROUND="drawable/ic_launcher_foreground" \
+            CANDY_FOSS_LAUNCHER_FOREGROUND="drawable/ic_launcher_foreground_foss" \
+            CANDY_USER_CA_LAUNCHER_FOREGROUND="drawable/ic_launcher_foreground_ca" \
+            CANDY_STANDARD_LAUNCHER_MONOCHROME="drawable/ic_launcher_monochrome" \
+            CANDY_FOSS_LAUNCHER_MONOCHROME="drawable/ic_launcher_monochrome_foss" \
+            CANDY_USER_CA_LAUNCHER_MONOCHROME="drawable/ic_launcher_monochrome_ca" \
             python3 scripts/test_network_security_apks.py
 
       - name: Verify and checksum APKs
@@ -240,7 +253,7 @@ jobs:
           set -euo pipefail
 
           release_apk="CandyBrowser-${RELEASE_TAG}-release.apk"
-          user_ca_release_apk="CandyBrowser-${RELEASE_TAG}-user-ca-release.apk"
+          user_ca_release_apk="CandyBrowser-${RELEASE_TAG}-ca-release.apk"
           cp "app/build/outputs/apk/full/release/app-full-release.apk" "$release_apk"
           cp \
             "app/build/outputs/apk/full/userCaRelease/app-full-userCaRelease.apk" \

--- a/README.md
+++ b/README.md
@@ -241,22 +241,24 @@ Use the filtered setup link so Obtainium always selects the standard certificate
 
 <a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fapp%2F%7B%22id%22%3A%22dev.sk2andy.materialbrowser%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fsk2andy%2Fcandy-browser%22%2C%22author%22%3A%22sk2andy%22%2C%22name%22%3A%22Candy%20Browser%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22apkFilterRegEx%5C%22%3A%5C%22%5ECandyBrowser-v%5B0-9%5D%2B(%3F%3A%5C%5C%5C%5C.%5B0-9%5D%2B)%7B1%2C2%7D-release%5C%5C%5C%5C.apk%24%5C%22%7D%22%7D"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png" height="48" alt="Get it on Obtainium"></a>
 
-All GitHub APK channels use the same application ID and signing key. Obtainium can track only one
-of them at a time. Do not add the unfiltered repository URL: the release contains three installable
-APKs, and choosing the wrong asset can silently switch the installed feature set or certificate-trust
-policy.
+The standard and User CA channels use separate application IDs, so both can stay installed and keep
+independent profiles, settings, and caches. Keep the asset filter: it prevents Obtainium from
+selecting a different channel than the configured app.
 
 ### F-Droid
 
-Candy includes a `foss` distribution flavor for the official F-Droid repository. It removes Google
-Play services, Google Cast, Google Code Scanner, and Candy's GitHub update checker. Remote search
-suggestions default to off. F-Droid builds this variant from tagged public source and verifies it
-against Candy's upstream-signed FOSS APK.
+Candy includes a separately installable `foss` distribution flavor for the official F-Droid
+repository. It uses the application ID `dev.sk2andy.materialbrowser.foss`, removes Google Play
+services, Google Cast, Google Code Scanner, and Candy's GitHub update checker, and keeps its profiles,
+settings, and caches isolated from the other channels. Remote search suggestions default to off.
+F-Droid builds this variant from tagged public source and verifies it against Candy's upstream-signed
+FOSS APK.
 
-The first prepared F-Droid release is `0.31`. Submission files and the remaining maintainer steps
-live in [`distribution/fdroid`](distribution/fdroid/README.md). Candy publishes a signed FOSS
-reference APK so F-Droid can verify its source build and preserve update compatibility with the
-upstream signing key.
+The isolated F-Droid listing starts with `0.37`; older FOSS APKs used the universal application ID
+and cannot become versions of the new package. Submission files and maintainer steps live in
+[`distribution/fdroid`](distribution/fdroid/README.md). Candy publishes a signed FOSS reference APK
+so F-Droid can verify its source build and preserve update compatibility with the upstream signing
+key.
 
 Releases contain three APK channels:
 
@@ -264,12 +266,19 @@ Releases contain three APK channels:
 | --- | --- | --- |
 | `-release.apk` | Android system CAs only | Recommended default |
 | `-foss-release.apk` | Android system CAs only | F-Droid reproducible-build reference without proprietary Google integrations |
-| `-user-ca-release.apk` | System CAs plus every CA in Android's user store | Explicit opt-in for HTTPS filtering/proxy tools such as AdGuard |
+| `-ca-release.apk` | System CAs plus every CA in Android's user store | Explicit opt-in for HTTPS filtering/proxy tools such as AdGuard |
 
-The User CA build has the same application ID and signing key as the other builds, so installing it
-replaces another channel without clearing Candy's data. Its launcher label and the warning under
-**Settings → Protection & data** identify the broader trust policy. Updates stay on the installed
-channel.
+The standard build uses `dev.sk2andy.materialbrowser`, the FOSS build uses
+`dev.sk2andy.materialbrowser.foss`, and the User CA build uses
+`dev.sk2andy.materialbrowser.ca`. Android therefore installs all three side by side with isolated
+app data. Their launcher labels and badged icons distinguish the channels; the warning under
+**Settings → Protection & data** additionally identifies the User CA build's broader trust policy.
+Updates stay on the installed channel.
+
+Releases through v0.36 used the standard application ID for all three APKs. Android cannot migrate
+an installed package to a different application ID, so the isolated FOSS and CA channels start with
+fresh app data. The new CA asset name is `-ca-release.apk`; legacy CA installs therefore do not get
+offered an incompatible package as an in-place update.
 
 **Security warning:** a trusted user CA can inspect and modify all HTTPS traffic made by Candy,
 including normal and private tabs, suggestions, filter subscriptions, and update metadata. Only
@@ -278,7 +287,7 @@ that controls its private key. APK signature verification still protects Candy u
 signed by another key.
 
 Advanced users who intentionally need this channel can use the
-[filtered User CA Obtainium setup](https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fapp%2F%7B%22id%22%3A%22dev.sk2andy.materialbrowser%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fsk2andy%2Fcandy-browser%22%2C%22author%22%3A%22sk2andy%22%2C%22name%22%3A%22Candy%20Browser%20User%20CA%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22apkFilterRegEx%5C%22%3A%5C%22%5ECandyBrowser-v%5B0-9%5D%2B(%3F%3A%5C%5C%5C%5C.%5B0-9%5D%2B)%7B1%2C2%7D-user-ca-release%5C%5C%5C%5C.apk%24%5C%22%7D%22%7D).
+[filtered User CA Obtainium setup](https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fapp%2F%7B%22id%22%3A%22dev.sk2andy.materialbrowser.ca%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fsk2andy%2Fcandy-browser%22%2C%22author%22%3A%22sk2andy%22%2C%22name%22%3A%22Candy%20CA%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22apkFilterRegEx%5C%22%3A%5C%22%5ECandyBrowser-v%5B0-9%5D%2B(%3F%3A%5C%5C%5C%5C.%5B0-9%5D%2B)%7B1%2C2%7D-ca-release%5C%5C%5C%5C.apk%24%5C%22%7D%22%7D).
 
 ## Build from source
 
@@ -302,7 +311,7 @@ python3 scripts/test_network_security_apks.py
 ```
 
 Debug APK: `app/build/outputs/apk/full/debug/app-full-debug.apk`. It installs as
-`dev.sk2andy.materialbrowser.debug`, uses the label `Candy Browser Debug`, and has a badged launcher
+`dev.sk2andy.materialbrowser.linkpeek`, uses the label `Candy Link Peek`, and has a badged launcher
 icon, so it can stay installed beside the release app.
 
 ### Signed release builds
@@ -346,9 +355,9 @@ Signed local APK: `app/build/outputs/apk/full/localRelease/app-full-localRelease
 `localRelease` installs beside the GitHub build as `dev.sk2andy.materialbrowser.local` and uses a
 separate launcher icon and the label `Candy Browser Local`. GitHub update prompts are disabled for
 this side-by-side build because production APKs cannot update its package. The GitHub release
-workflow uses `assembleFullRelease`, `assembleFossRelease`, and `assembleFullUserCaRelease`; all
-preserve the production application ID and icon. A separate workflow signs and publishes the FOSS
-output from explicitly allowlisted release tags.
+workflow uses `assembleFullRelease`, `assembleFossRelease`, and `assembleFullUserCaRelease`; those
+outputs use the standard, `.foss`, and `.ca` application IDs and matching launcher identities. A
+separate workflow signs and publishes the FOSS output from explicitly allowlisted release tags.
 
 ### GitHub releases
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,6 +152,8 @@ android {
 
         create("foss") {
             dimension = "distribution"
+            applicationIdSuffix = ".foss"
+            manifestPlaceholders["appLabel"] = "Candy FOSS"
             buildConfigField("boolean", "FOSS_DISTRIBUTION", "true")
         }
     }
@@ -197,7 +199,8 @@ android {
 
         create("userCaDebug") {
             initWith(getByName("debug"))
-            manifestPlaceholders["appLabel"] = "Candy Browser User CA Debug"
+            applicationIdSuffix = ".ca.debug"
+            manifestPlaceholders["appLabel"] = "Candy CA Debug"
             manifestPlaceholders["networkSecurityConfig"] =
                 "@xml/network_security_config_user_ca"
             buildConfigField("boolean", "TRUST_USER_CERTIFICATES", "true")
@@ -206,7 +209,8 @@ android {
 
         create("userCaRelease") {
             initWith(getByName("release"))
-            manifestPlaceholders["appLabel"] = "Candy Browser User CA"
+            applicationIdSuffix = ".ca"
+            manifestPlaceholders["appLabel"] = "Candy CA"
             manifestPlaceholders["networkSecurityConfig"] =
                 "@xml/network_security_config_user_ca"
             buildConfigField("boolean", "TRUST_USER_CERTIFICATES", "true")

--- a/app/src/foss/res/drawable/ic_launcher_background_foss.xml
+++ b/app/src/foss/res/drawable/ic_launcher_background_foss.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#E8F5E9" />
+</shape>

--- a/app/src/foss/res/drawable/ic_launcher_foreground_foss.xml
+++ b/app/src/foss/res/drawable/ic_launcher_foreground_foss.xml
@@ -1,0 +1,4 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+    <item android:drawable="@drawable/ic_launcher_foss_badge" />
+</layer-list>

--- a/app/src/foss/res/drawable/ic_launcher_foss_badge.xml
+++ b/app/src/foss/res/drawable/ic_launcher_foss_badge.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#66BB6A"
+        android:pathData="M79,62A17,17 0,1 1,78.99 62Z"
+        android:strokeColor="#FFF8E1"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="#17351D"
+        android:pathData="M72,69L88,69L88,74L78,74L78,78L86,78L86,83L78,83L78,89L72,89Z" />
+</vector>

--- a/app/src/foss/res/drawable/ic_launcher_foss_badge_monochrome.xml
+++ b/app/src/foss/res/drawable/ic_launcher_foss_badge_monochrome.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M64,64L94,64L94,94L64,94Z" />
+</vector>

--- a/app/src/foss/res/drawable/ic_launcher_monochrome_foss.xml
+++ b/app/src/foss/res/drawable/ic_launcher_monochrome_foss.xml
@@ -1,0 +1,4 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_monochrome" />
+    <item android:drawable="@drawable/ic_launcher_foss_badge_monochrome" />
+</layer-list>

--- a/app/src/foss/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/foss/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background_foss" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_foss" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome_foss" />
+</adaptive-icon>

--- a/app/src/foss/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/foss/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background_foss" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_foss" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome_foss" />
+</adaptive-icon>

--- a/app/src/main/java/dev/sk2andy/materialbrowser/update/AppUpdate.kt
+++ b/app/src/main/java/dev/sk2andy/materialbrowser/update/AppUpdate.kt
@@ -29,7 +29,7 @@ internal enum class AppReleaseChannel(
     val assetSuffix: String,
 ) {
     Standard("release"),
-    UserCa("user-ca-release"),
+    UserCa("ca-release"),
 
     ;
 

--- a/app/src/test/java/dev/sk2andy/materialbrowser/BuildVariantContractTest.kt
+++ b/app/src/test/java/dev/sk2andy/materialbrowser/BuildVariantContractTest.kt
@@ -25,4 +25,24 @@ class BuildVariantContractTest {
 
         assertEquals(expectedFoss, BuildConfig.FOSS_DISTRIBUTION)
     }
+
+    @Test
+    fun `production application identity isolates release channels`() {
+        val flavorSuffix = when (BuildConfig.FLAVOR) {
+            "full" -> ""
+            "foss" -> ".foss"
+            else -> error("Unknown flavor: ${BuildConfig.FLAVOR}")
+        }
+        val buildTypeSuffix = when (BuildConfig.BUILD_TYPE) {
+            "release" -> ""
+            "userCaRelease" -> ".ca"
+            "debug", "localRelease", "userCaDebug" -> return
+            else -> error("Unknown build type: ${BuildConfig.BUILD_TYPE}")
+        }
+
+        assertEquals(
+            "dev.sk2andy.materialbrowser$flavorSuffix$buildTypeSuffix",
+            BuildConfig.APPLICATION_ID,
+        )
+    }
 }

--- a/app/src/test/java/dev/sk2andy/materialbrowser/update/AppUpdateRulesTest.kt
+++ b/app/src/test/java/dev/sk2andy/materialbrowser/update/AppUpdateRulesTest.kt
@@ -38,7 +38,7 @@ class AppUpdateRulesTest {
     @Test
     fun `keeps user CA installs on user CA release channel`() {
         val standardAsset = asset("v0.9", suffix = "release")
-        val userCaAsset = asset("v0.9", suffix = "user-ca-release")
+        val userCaAsset = asset("v0.9", suffix = "ca-release")
 
         val update = AppUpdateRules.findAvailableUpdate(
             currentVersionName = "0.8",
@@ -46,7 +46,7 @@ class AppUpdateRulesTest {
             channel = AppReleaseChannel.UserCa,
         )
 
-        assertEquals("CandyBrowser-v0.9-user-ca-release.apk", update?.fileName)
+        assertEquals("CandyBrowser-v0.9-ca-release.apk", update?.fileName)
     }
 
     @Test
@@ -55,6 +55,20 @@ class AppUpdateRulesTest {
             AppUpdateRules.findAvailableUpdate(
                 currentVersionName = "0.8",
                 release = release("v0.9"),
+                channel = AppReleaseChannel.UserCa,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not offer legacy shared identity user CA asset`() {
+        assertNull(
+            AppUpdateRules.findAvailableUpdate(
+                currentVersionName = "0.8",
+                release = release(
+                    "v0.9",
+                    assets = listOf(asset("v0.9", suffix = "user-ca-release")),
+                ),
                 channel = AppReleaseChannel.UserCa,
             ),
         )

--- a/app/src/userCa/res/drawable/ic_launcher_background_ca.xml
+++ b/app/src/userCa/res/drawable/ic_launcher_background_ca.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#FFF3E0" />
+</shape>

--- a/app/src/userCa/res/drawable/ic_launcher_ca_badge.xml
+++ b/app/src/userCa/res/drawable/ic_launcher_ca_badge.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF8A65"
+        android:pathData="M79,62A17,17 0,1 1,78.99 62Z"
+        android:strokeColor="#FFF8E1"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M77,71C71,68 67,72 67,79C67,86 71,90 77,87"
+        android:strokeColor="#3E1B12"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="3" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M80,88L86,70L92,88M82,82L90,82"
+        android:strokeColor="#3E1B12"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="3" />
+</vector>

--- a/app/src/userCa/res/drawable/ic_launcher_ca_badge_monochrome.xml
+++ b/app/src/userCa/res/drawable/ic_launcher_ca_badge_monochrome.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M79,62L95,68L92,88L79,96L66,88L63,68Z" />
+</vector>

--- a/app/src/userCa/res/drawable/ic_launcher_foreground_ca.xml
+++ b/app/src/userCa/res/drawable/ic_launcher_foreground_ca.xml
@@ -1,0 +1,4 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+    <item android:drawable="@drawable/ic_launcher_ca_badge" />
+</layer-list>

--- a/app/src/userCa/res/drawable/ic_launcher_monochrome_ca.xml
+++ b/app/src/userCa/res/drawable/ic_launcher_monochrome_ca.xml
@@ -1,0 +1,4 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_monochrome" />
+    <item android:drawable="@drawable/ic_launcher_ca_badge_monochrome" />
+</layer-list>

--- a/app/src/userCa/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/userCa/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background_ca" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_ca" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome_ca" />
+</adaptive-icon>

--- a/app/src/userCa/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/userCa/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background_ca" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_ca" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome_ca" />
+</adaptive-icon>

--- a/distribution/fdroid/README.md
+++ b/distribution/fdroid/README.md
@@ -1,34 +1,37 @@
 # F-Droid submission
 
 Candy's `foss` flavor is the only variant intended for the official F-Droid repository. It uses the
-same application ID as the GitHub build but excludes Google Play services, Google Cast, Google Code
-Scanner, and the GitHub self-updater. New FOSS installs keep remote search suggestions disabled
-until the user explicitly chooses a provider.
+isolated application ID `dev.sk2andy.materialbrowser.foss` and excludes Google Play services,
+Google Cast, Google Code Scanner, and the GitHub self-updater. New FOSS installs keep remote search
+suggestions disabled until the user explicitly chooses a provider.
 
 ## Submission
 
+The isolated listing starts at v0.37. Do not copy the v0.31–v0.36 build blocks from the former
+`dev.sk2andy.materialbrowser` submission: those APKs use the universal application ID and are not
+valid versions of `dev.sk2andy.materialbrowser.foss`.
+
 1. Run the `Release Android APK` workflow. It must create the version tag from the exact commit that
    contains the matching `candy.versionName` and `candy.versionCode` values.
-2. For releases created before signed FOSS assets were enabled, run the backfill workflow from the
-   default branch:
+2. Allowlist the immutable tag commit in `publish-fdroid-reference.yml`, then publish its signed FOSS
+   reference APK:
 
    ```bash
-   gh workflow run publish-fdroid-reference.yml -f tag=v0.31
-   gh workflow run publish-fdroid-reference.yml -f tag=v0.32
+   gh workflow run publish-fdroid-reference.yml -f tag=v0.37
    ```
 
 3. Verify that each signed FOSS asset uses the pinned certificate fingerprint and matches the
    independently built F-Droid APK byte for byte apart from signing.
-4. Copy `dev.sk2andy.materialbrowser.yml` into a fork of `fdroid/fdroiddata` as
-   `metadata/dev.sk2andy.materialbrowser.yml`.
+4. Copy `dev.sk2andy.materialbrowser.foss.yml` into a fork of `fdroid/fdroiddata` as
+   `metadata/dev.sk2andy.materialbrowser.foss.yml`.
 5. Validate from the fdroiddata checkout:
 
    ```bash
    fdroid readmeta
-   fdroid rewritemeta dev.sk2andy.materialbrowser
-   fdroid checkupdates dev.sk2andy.materialbrowser
-   fdroid lint dev.sk2andy.materialbrowser
-   fdroid build -v -l dev.sk2andy.materialbrowser
+   fdroid rewritemeta dev.sk2andy.materialbrowser.foss
+   fdroid checkupdates dev.sk2andy.materialbrowser.foss
+   fdroid lint dev.sk2andy.materialbrowser.foss
+   fdroid build -v -l dev.sk2andy.materialbrowser.foss
    ```
 
 6. Open a merge request against `fdroid/fdroiddata`. Include the successful local-build log and

--- a/distribution/fdroid/dev.sk2andy.materialbrowser.foss.yml
+++ b/distribution/fdroid/dev.sk2andy.materialbrowser.foss.yml
@@ -14,21 +14,9 @@ Repo: https://github.com/sk2andy/candy-browser.git
 Binaries: https://github.com/sk2andy/candy-browser/releases/download/v%v/CandyBrowser-v%v-foss-release.apk
 
 Builds:
-  - versionName: '0.31'
-    versionCode: 31000
-    commit: 724187d01e7472fa9e7151ebe825fdd18acb199d
-    subdir: app
-    gradle:
-      - foss
-  - versionName: '0.32'
-    versionCode: 32000
-    commit: 65a93dc6b962cbae492226ac896dac60026939ef
-    subdir: app
-    gradle:
-      - foss
-  - versionName: '0.33'
-    versionCode: 33000
-    commit: 4d7400de2ee3316743e69fefe396fe5807ad0b9d
+  - versionName: '0.37'
+    versionCode: 37000
+    commit: v0.37
     subdir: app
     gradle:
       - foss
@@ -38,5 +26,5 @@ AllowedAPKSigningKeys: e65082d293039290b24b6ef689996cf42f8e8b61966a2ebe4f49d9f8e
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^v[0-9]+(\.[0-9]+){1,2}$
 UpdateCheckData: gradle.properties|candy.versionCode=(\d+)|.|candy.versionName=(.+)
-CurrentVersion: '0.33'
-CurrentVersionCode: 33000
+CurrentVersion: '0.37'
+CurrentVersionCode: 37000

--- a/distribution/obtainium/README.md
+++ b/distribution/obtainium/README.md
@@ -1,17 +1,17 @@
 # Obtainium listing
 
-GitHub Releases already expose stable, signed APK assets. Candy needs explicit filters because the
-standard and User CA channels share one package ID, version, and signing key.
+GitHub Releases already expose stable, signed APK assets. Candy needs explicit filters so each
+separately installable package stays on its selected release channel.
 
 | Channel | APK filter |
 | --- | --- |
 | Standard | `^CandyBrowser-v[0-9]+(?:\.[0-9]+){1,2}-release\.apk$` |
-| User CA | `^CandyBrowser-v[0-9]+(?:\.[0-9]+){1,2}-user-ca-release\.apk$` |
+| User CA | `^CandyBrowser-v[0-9]+(?:\.[0-9]+){1,2}-ca-release\.apk$` |
 
 `dev.sk2andy.materialbrowser.json` is ready to copy into the Obtainium community-listing repository
 at `public/data/apps/complex/dev.sk2andy.materialbrowser.json`. Open a pull request against
-`ImranR98/apps.obtainium.imranr.dev`; the two entries represent mutually exclusive choices, not
-parallel installations.
+`ImranR98/apps.obtainium.imranr.dev`; the two entries use separate package IDs and can be installed
+in parallel.
 
 The README's main Obtainium badge uses only the standard filter. Keep the User CA link secondary
 and beside its security warning. If prerelease APKs are introduced later, add a separately labeled

--- a/distribution/obtainium/dev.sk2andy.materialbrowser.json
+++ b/distribution/obtainium/dev.sk2andy.materialbrowser.json
@@ -9,11 +9,11 @@
       "altLabel": "Standard (recommended)"
     },
     {
-      "id": "dev.sk2andy.materialbrowser",
+      "id": "dev.sk2andy.materialbrowser.ca",
       "url": "https://github.com/sk2andy/candy-browser",
       "author": "sk2andy",
-      "name": "Candy Browser User CA",
-      "additionalSettings": "{\"apkFilterRegEx\":\"^CandyBrowser-v[0-9]+(?:\\\\.[0-9]+){1,2}-user-ca-release\\\\.apk$\"}",
+      "name": "Candy CA",
+      "additionalSettings": "{\"apkFilterRegEx\":\"^CandyBrowser-v[0-9]+(?:\\\\.[0-9]+){1,2}-ca-release\\\\.apk$\"}",
       "altLabel": "User CA (advanced)"
     }
   ],

--- a/docs/browsing/runtime-and-navigation.md
+++ b/docs/browsing/runtime-and-navigation.md
@@ -147,15 +147,16 @@
 
 ## TLS trust channels
 
-| Build | Trust anchors | Release asset |
-| --- | --- | --- |
-| Standard | Android system CA store | `CandyBrowser-v<version>-release.apk` |
-| User CA | Android system and user CA stores | `CandyBrowser-v<version>-user-ca-release.apk` |
+| Build | Application ID | Trust anchors | Release asset |
+| --- | --- | --- | --- |
+| Standard | `dev.sk2andy.materialbrowser` | Android system CA store | `CandyBrowser-v<version>-release.apk` |
+| User CA | `dev.sk2andy.materialbrowser.ca` | Android system and user CA stores | `CandyBrowser-v<version>-ca-release.apk` |
 
 - Network Security Config is static and app-wide. Android WebView cannot safely switch trust anchors
   from a runtime preference, so broader trust requires installing the explicitly labeled User CA APK.
-- Both channels use the same application ID and signing key. Update selection preserves the installed
-  channel and rejects a release that contains only the other channel's asset.
+- Separate application IDs isolate app data and allow both channels to stay installed. Update
+  selection preserves the installed channel and rejects a release that contains only the other
+  channel's asset.
 - User CA trust applies to all app HTTPS connections, not only rendered pages or a selected profile.
   The settings warning must remain visible in User CA builds.
 - `BrowserController.onReceivedSslError` always cancels. Only an error URL matching the current
@@ -263,4 +264,4 @@ WebView request state.
 | WebView reverse-flick momentum | `BrowserMomentumRecoveryRulesTest` plus `BrowserScrollInstrumentedTest#busyLongPageKeepsEveryRapidAlternatingFlick` on the affected WebView version |
 | Web media, fullscreen and PiP policy | `WebMediaContractTest`, `WebMediaBridgeInstrumentedTest`, `FullscreenVideoRulesTest`, `FullscreenVideoInstrumentedTest`, `FullscreenVideoActivityInstrumentedTest` and `FullscreenVideoOverlayInstrumentedTest` on API 34+ |
 | Android intent routing | `IncomingBrowserIntentInstrumentedTest`, `BrowserIntentFilterInstrumentedTest`, plus `MainActivityExternalBackInstrumentedTest` when lifecycle matters |
-| TLS trust channels | `./gradlew testFullDebugUnitTest testFullUserCaDebugUnitTest assembleFullDebug assembleFullUserCaDebug`, then `python3 scripts/test_network_security_apks.py` |
+| Distribution and TLS channels | `./gradlew testFullDebugUnitTest testFossDebugUnitTest testFullUserCaDebugUnitTest assembleFullDebug assembleFossDebug assembleFullUserCaDebug`, then `python3 scripts/test_network_security_apks.py` |

--- a/fastlane/metadata/android/de-DE/changelogs/37000.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/37000.txt
@@ -1,0 +1,1 @@
+Installiere Universal-, FOSS- und CA-Builds parallel – mit getrennten App-Daten und klar gekennzeichneten Launcher-Icons.

--- a/fastlane/metadata/android/en-US/changelogs/37000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/37000.txt
@@ -1,0 +1,1 @@
+Install Universal, FOSS, and CA builds side by side with isolated app data and clearly badged launcher icons.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-candy.versionName=0.36
-candy.versionCode=36000
+candy.versionName=0.37
+candy.versionCode=37000

--- a/release-notes/0.37.md
+++ b/release-notes/0.37.md
@@ -1,0 +1,29 @@
+# Install every Candy channel side by side
+
+Candy Browser 0.37 gives the Universal, FOSS, and CA builds separate Android identities. You can
+keep all three installed without one build replacing another or sharing profiles, settings, or
+caches.
+
+## Pick the right channel at a glance
+
+- **Candy Browser** remains the universal build with optional Google-backed integrations.
+- **Candy FOSS** has its own package and a green `F` badge. It keeps Google Play services and the
+  built-in GitHub updater out of the F-Droid build.
+- **Candy CA** has its own package and an orange `CA` badge. It remains the explicit opt-in build for
+  devices that need Android user certificate authorities.
+- Launcher shortcuts now target the exact installed package for every channel.
+
+Learn more in [Runtime and navigation](https://github.com/sk2andy/candy-browser/blob/v0.37/docs/browsing/runtime-and-navigation.md#tls-trust-channels).
+
+## Migration note
+
+Releases through v0.36 used one application ID for all channels. Android cannot move app data to a
+new application ID, so Candy FOSS and Candy CA start with fresh profiles and settings when first
+installed. The existing installation remains available until you remove it.
+
+The CA download now ends in `-ca-release.apk`. This prevents a legacy User CA installation from
+offering the new separate package as an incompatible in-place update.
+
+Implements [#107](https://github.com/sk2andy/candy-browser/issues/107).
+
+[Full changelog](https://github.com/sk2andy/candy-browser/compare/v0.36...v0.37)

--- a/scripts/test_network_security_apks.py
+++ b/scripts/test_network_security_apks.py
@@ -20,6 +20,51 @@ USER_CA_APK = Path(
         PROJECT_ROOT / "app/build/outputs/apk/full/userCaDebug/app-full-userCaDebug.apk",
     ),
 )
+FOSS_APK = Path(
+    os.environ.get(
+        "CANDY_FOSS_APK",
+        PROJECT_ROOT / "app/build/outputs/apk/foss/debug/app-foss-debug.apk",
+    ),
+)
+STANDARD_APPLICATION_ID = os.environ.get(
+    "CANDY_STANDARD_APPLICATION_ID",
+    "dev.sk2andy.materialbrowser.linkpeek",
+)
+FOSS_APPLICATION_ID = os.environ.get(
+    "CANDY_FOSS_APPLICATION_ID",
+    "dev.sk2andy.materialbrowser.foss.linkpeek",
+)
+USER_CA_APPLICATION_ID = os.environ.get(
+    "CANDY_USER_CA_APPLICATION_ID",
+    "dev.sk2andy.materialbrowser.ca.debug",
+)
+STANDARD_APP_LABEL = os.environ.get("CANDY_STANDARD_APP_LABEL", "Candy Link Peek")
+FOSS_APP_LABEL = os.environ.get("CANDY_FOSS_APP_LABEL", "Candy Link Peek")
+USER_CA_APP_LABEL = os.environ.get("CANDY_USER_CA_APP_LABEL", "Candy CA Debug")
+STANDARD_LAUNCHER_FOREGROUND = os.environ.get(
+    "CANDY_STANDARD_LAUNCHER_FOREGROUND",
+    "drawable/ic_launcher_foreground_debug",
+)
+FOSS_LAUNCHER_FOREGROUND = os.environ.get(
+    "CANDY_FOSS_LAUNCHER_FOREGROUND",
+    "drawable/ic_launcher_foreground_debug",
+)
+USER_CA_LAUNCHER_FOREGROUND = os.environ.get(
+    "CANDY_USER_CA_LAUNCHER_FOREGROUND",
+    "drawable/ic_launcher_foreground_ca",
+)
+STANDARD_LAUNCHER_MONOCHROME = os.environ.get(
+    "CANDY_STANDARD_LAUNCHER_MONOCHROME",
+    "drawable/ic_launcher_monochrome_debug",
+)
+FOSS_LAUNCHER_MONOCHROME = os.environ.get(
+    "CANDY_FOSS_LAUNCHER_MONOCHROME",
+    "drawable/ic_launcher_monochrome_debug",
+)
+USER_CA_LAUNCHER_MONOCHROME = os.environ.get(
+    "CANDY_USER_CA_LAUNCHER_MONOCHROME",
+    "drawable/ic_launcher_monochrome_ca",
+)
 
 
 def build_tools_version(path: Path) -> tuple[int, ...]:
@@ -70,6 +115,37 @@ def xml_resources(output: str) -> dict[str, tuple[str, str]]:
     }
 
 
+def resource_names(output: str) -> dict[str, str]:
+    return {
+        resource_id.lower(): name
+        for resource_id, name in re.findall(
+            r"resource (0x[0-9a-fA-F]+) ([A-Za-z0-9_]+/[A-Za-z0-9_]+)",
+            output,
+        )
+    }
+
+
+def resource_files(output: str) -> dict[str, str]:
+    return {
+        name: file_path
+        for name, file_path in re.findall(
+            r"resource 0x[0-9a-fA-F]+ ([A-Za-z0-9_]+/[A-Za-z0-9_]+)\s+"
+            r"\([^)]*\) \(file\) ([^ ]+) type=[A-Z]+",
+            output,
+        )
+    }
+
+
+def resource_string_values(output: str) -> dict[str, str]:
+    return {
+        resource_id.lower(): value
+        for resource_id, value in re.findall(
+            r"resource (0x[0-9a-fA-F]+) string/[A-Za-z0-9_]+\s+\(\) \"([^\"]*)\"",
+            output,
+        )
+    }
+
+
 def manifest_package(output: str) -> str:
     match = re.search(r'^\s*A: package="([^"]+)"', output, re.MULTILINE)
     if match is None:
@@ -77,11 +153,44 @@ def manifest_package(output: str) -> str:
     return match.group(1)
 
 
-def manifest_label(output: str) -> str:
+def manifest_label(output: str, string_values: dict[str, str]) -> str:
     match = re.search(r':label\([^)]*\)="([^"]+)"', output)
+    if match is not None:
+        return match.group(1)
+    reference = re.search(r":label\([^)]*\)=@(0x[0-9a-fA-F]+)", output)
+    if reference is None:
+        raise AssertionError("Application label missing from aapt2 output.")
+    resource_id = reference.group(1).lower()
+    if resource_id not in string_values:
+        raise AssertionError(f"Application label value missing for resource: {resource_id}")
+    return string_values[resource_id]
+
+
+def referenced_resource(output: str, attribute: str, resources: dict[str, str]) -> str:
+    match = re.search(
+        rf":{re.escape(attribute)}\([^)]*\)=@(0x[0-9a-fA-F]+)",
+        output,
+    )
     if match is None:
-        raise AssertionError("Resolved application label missing from aapt2 output.")
-    return match.group(1)
+        raise AssertionError(f"Resource attribute missing: {attribute}")
+    resource_id = match.group(1).lower()
+    if resource_id not in resources:
+        raise AssertionError(f"Unknown resource ID for {attribute}: {resource_id}")
+    return resources[resource_id]
+
+
+def adaptive_icon_layer(output: str, layer: str, resources: dict[str, str]) -> str:
+    match = re.search(
+        rf"E: {re.escape(layer)}[^\n]*\n\s+A: .*:drawable\([^)]*\)="
+        r"@(0x[0-9a-fA-F]+)",
+        output,
+    )
+    if match is None:
+        raise AssertionError(f"Adaptive icon layer missing: {layer}")
+    resource_id = match.group(1).lower()
+    if resource_id not in resources:
+        raise AssertionError(f"Unknown resource ID for {layer}: {resource_id}")
+    return resources[resource_id]
 
 
 def manifest_network_config(
@@ -128,12 +237,27 @@ class NetworkSecurityApkTest(unittest.TestCase):
             "xmltree",
             "AndroidManifest.xml",
         )
-        cls.standard_resources = xml_resources(
-            aapt2_dump(cls.aapt2, STANDARD_APK, "resources"),
+        cls.foss_manifest = aapt2_dump(
+            cls.aapt2,
+            FOSS_APK,
+            "xmltree",
+            "AndroidManifest.xml",
         )
-        cls.user_ca_resources = xml_resources(
-            aapt2_dump(cls.aapt2, USER_CA_APK, "resources"),
-        )
+        cls.standard_resource_dump = aapt2_dump(cls.aapt2, STANDARD_APK, "resources")
+        cls.foss_resource_dump = aapt2_dump(cls.aapt2, FOSS_APK, "resources")
+        cls.user_ca_resource_dump = aapt2_dump(cls.aapt2, USER_CA_APK, "resources")
+        cls.standard_resources = xml_resources(cls.standard_resource_dump)
+        cls.user_ca_resources = xml_resources(cls.user_ca_resource_dump)
+        cls.foss_resources = xml_resources(cls.foss_resource_dump)
+        cls.standard_resource_names = resource_names(cls.standard_resource_dump)
+        cls.foss_resource_names = resource_names(cls.foss_resource_dump)
+        cls.user_ca_resource_names = resource_names(cls.user_ca_resource_dump)
+        cls.standard_resource_files = resource_files(cls.standard_resource_dump)
+        cls.foss_resource_files = resource_files(cls.foss_resource_dump)
+        cls.user_ca_resource_files = resource_files(cls.user_ca_resource_dump)
+        cls.standard_string_values = resource_string_values(cls.standard_resource_dump)
+        cls.foss_string_values = resource_string_values(cls.foss_resource_dump)
+        cls.user_ca_string_values = resource_string_values(cls.user_ca_resource_dump)
 
     def test_standard_apk_trusts_only_system_certificates(self):
         self.assertEqual(
@@ -167,12 +291,89 @@ class NetworkSecurityApkTest(unittest.TestCase):
         self.assertIn("cleartextTrafficPermitted=true", config)
         self.assertEqual(["system", "user"], certificate_sources(config))
 
-    def test_channels_share_package_identity_and_user_ca_label_is_explicit(self):
+    def test_foss_apk_trusts_only_system_certificates(self):
         self.assertEqual(
-            manifest_package(self.standard_manifest),
-            manifest_package(self.user_ca_manifest),
+            "network_security_config",
+            manifest_network_config(self.foss_manifest, self.foss_resources),
         )
-        self.assertIn("User CA", manifest_label(self.user_ca_manifest))
+        self.assertNotIn(
+            "network_security_config_user_ca",
+            [name for name, _ in self.foss_resources.values()],
+        )
+        config = aapt2_dump(
+            self.aapt2,
+            FOSS_APK,
+            "xmltree",
+            xml_resource_file(self.foss_resources, "network_security_config"),
+        )
+        self.assertIn("cleartextTrafficPermitted=true", config)
+        self.assertEqual(["system"], certificate_sources(config))
+
+    def test_channels_use_isolated_package_identities_and_explicit_labels(self):
+        self.assertEqual(STANDARD_APPLICATION_ID, manifest_package(self.standard_manifest))
+        self.assertEqual(FOSS_APPLICATION_ID, manifest_package(self.foss_manifest))
+        self.assertEqual(USER_CA_APPLICATION_ID, manifest_package(self.user_ca_manifest))
+        self.assertEqual(
+            STANDARD_APP_LABEL,
+            manifest_label(self.standard_manifest, self.standard_string_values),
+        )
+        self.assertEqual(
+            FOSS_APP_LABEL,
+            manifest_label(self.foss_manifest, self.foss_string_values),
+        )
+        self.assertEqual(
+            USER_CA_APP_LABEL,
+            manifest_label(self.user_ca_manifest, self.user_ca_string_values),
+        )
+
+    def test_channels_use_distinct_launcher_identity_resources(self):
+        manifests_and_resources = (
+            (
+                STANDARD_APK,
+                self.standard_manifest,
+                self.standard_resource_names,
+                self.standard_resource_files,
+                STANDARD_LAUNCHER_FOREGROUND,
+                STANDARD_LAUNCHER_MONOCHROME,
+            ),
+            (
+                FOSS_APK,
+                self.foss_manifest,
+                self.foss_resource_names,
+                self.foss_resource_files,
+                FOSS_LAUNCHER_FOREGROUND,
+                FOSS_LAUNCHER_MONOCHROME,
+            ),
+            (
+                USER_CA_APK,
+                self.user_ca_manifest,
+                self.user_ca_resource_names,
+                self.user_ca_resource_files,
+                USER_CA_LAUNCHER_FOREGROUND,
+                USER_CA_LAUNCHER_MONOCHROME,
+            ),
+        )
+        for apk, manifest, resources, files, expected_foreground, expected_monochrome in (
+            manifests_and_resources
+        ):
+            for manifest_attribute in ("icon", "roundIcon"):
+                launcher_name = referenced_resource(manifest, manifest_attribute, resources)
+                if launcher_name not in files:
+                    raise AssertionError(f"Launcher resource file missing: {launcher_name}")
+                launcher = aapt2_dump(
+                    self.aapt2,
+                    apk,
+                    "xmltree",
+                    files[launcher_name],
+                )
+                self.assertEqual(
+                    expected_foreground,
+                    adaptive_icon_layer(launcher, "foreground", resources),
+                )
+                self.assertEqual(
+                    expected_monochrome,
+                    adaptive_icon_layer(launcher, "monochrome", resources),
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Give Universal, FOSS, and User CA releases separate Android identities so all three can be installed side by side with isolated profiles, settings, and caches.

## Channel contract

| Channel | Application ID | Launcher label |
| --- | --- | --- |
| Universal | `dev.sk2andy.materialbrowser` | `Candy Browser` |
| FOSS | `dev.sk2andy.materialbrowser.foss` | `Candy FOSS` |
| User CA | `dev.sk2andy.materialbrowser.ca` | `Candy CA` |

FOSS and CA also receive distinct color and themed launcher badges. Compiled APK checks cover package IDs, labels, normal and round icons, monochrome layers, and certificate trust anchors.

## Release and migration

This prepares v0.37 as the first isolated-channel release. Releases through v0.36 used the universal package ID for every APK, so Android cannot migrate FOSS or CA app data automatically.

The new CA package uses the `-ca-release.apk` asset suffix. Legacy User CA installs therefore stay on their final compatible release instead of being offered an APK with a different package ID.

F-Droid metadata moves to `dev.sk2andy.materialbrowser.foss` and starts at v0.37; older binaries cannot be carried into the new listing because they contain the universal package ID.

Fixes #107